### PR TITLE
Make Tasks a data class

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/Task.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/Task.kt
@@ -22,7 +22,7 @@ import java.util.*
 /**
  * Immutable model class for a Task.
  */
-class Task
+data class Task
 /**
  * Use this constructor to specify a completed Task if the Task already has an id (copy of
  * another Task).

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -87,7 +87,7 @@ private constructor(val mTasksRemoteDataSource: TasksDataSource,
         mTasksRemoteDataSource.completeTask(task)
         mTasksLocalDataSource.completeTask(task)
 
-        val completedTask = Task(task.title, task.description, task.id, true)
+        val completedTask = task.copy(isCompleted = true)
 
         mCachedTasks.put(task.id, completedTask)
     }
@@ -100,7 +100,7 @@ private constructor(val mTasksRemoteDataSource: TasksDataSource,
         mTasksRemoteDataSource.activateTask(task)
         mTasksLocalDataSource.activateTask(task)
 
-        val activeTask = Task(task.title, task.description, task.id)
+        val activeTask = task.copy(isCompleted = false)
 
         mCachedTasks.put(task.id, activeTask)
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -56,7 +56,7 @@ private constructor() : TasksDataSource {
     }
 
     override fun completeTask(task: Task) {
-        val completedTask = Task(task.title, task.description, task.id, true)
+        val completedTask = task.copy(isCompleted = true)
         TASKS_SERVICE_DATA.put(task.id, completedTask)
     }
 
@@ -66,7 +66,7 @@ private constructor() : TasksDataSource {
     }
 
     override fun activateTask(task: Task) {
-        val activeTask = Task(task.title, task.description, task.id)
+        val activeTask = task.copy(isCompleted = false)
         TASKS_SERVICE_DATA.put(task.id, activeTask)
     }
 


### PR DESCRIPTION
Let's start small. The Tasks class should be a data class. The `equals` and `hashCode` have to be written manually because `isCompleted` is ignored. `toString` also has to be written manually because it is not "standard". A data class also generates `copy` and `componentN` methods. For this project the `copy` method can be used when activating/completing tasks. 